### PR TITLE
Add keep_warm.py to prevent cold starts

### DIFF
--- a/keep_warm.py
+++ b/keep_warm.py
@@ -1,0 +1,10 @@
+import requests
+import time
+
+url = "https://bikeshare-solomonrb.pythonanywhere.com/"
+
+try:
+    response = requests.get(url, timeout=30)
+    print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - Status: {response.status_code}")
+except Exception as e:
+    print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - Error: {e}")


### PR DESCRIPTION
## Summary
- Adds `keep_warm.py` script that pings the homepage to prevent PythonAnywhere cold starts
- Prevents Twilio timeout issues caused by app startup delays

## Setup
Schedule in PythonAnywhere Tasks:
```bash
python3 /home/solomonrb/keep_warm.py
```
Set to run hourly.

## How it works
PythonAnywhere puts idle apps to sleep after 24-26 hours. When a text arrives during cold start, app initialization + API calls can exceed Twilio's 15-second timeout. This script keeps the app warm by pinging it hourly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)